### PR TITLE
HOTFIX: Add integration test and remove miner nullification for the moment

### DIFF
--- a/neurons/__init__.py
+++ b/neurons/__init__.py
@@ -19,7 +19,7 @@
 # Define the version of the template module.
 from . import constants, protocol, safety
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/neurons/miners/__init__.py
+++ b/neurons/miners/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 version_split = __version__.split(".")
 
 __spec_version__ = (

--- a/neurons/utils/__init__.py
+++ b/neurons/utils/__init__.py
@@ -34,7 +34,7 @@ from neurons.constants import (
 from neurons.utils.log import colored_log
 
 from neurons.validator.utils.wandb import init_wandb
-from neurons.validator.rewards.types import (
+from neurons.validator.rewards.models.types import (
     RewardModelType,
 )
 

--- a/neurons/validator/__init__.py
+++ b/neurons/validator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/neurons/validator/event.py
+++ b/neurons/validator/event.py
@@ -2,7 +2,7 @@ from enum import Enum
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 def convert_enum_keys_to_strings(data) -> dict:

--- a/neurons/validator/forward.py
+++ b/neurons/validator/forward.py
@@ -32,7 +32,7 @@ from neurons.validator.backend.exceptions import PostMovingAveragesError
 from neurons.validator.event import EventSchema, convert_enum_keys_to_strings
 from neurons.validator.schemas import Batch
 from neurons.validator.utils import ttl_get_block
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 from neurons.validator.config import (
     get_device,
     get_metagraph,
@@ -479,12 +479,16 @@ async def run_step(
     )
 
     # Apply isalive filtering
-    rewards_tensor_adjusted = filter_rewards(
-        validator.isalive_dict,
-        validator.isalive_threshold,
-        # No need for scattering, directly use the rewards
-        scoring_results.combined_scores,
-    )
+    rewards_tensor_adjusted = scoring_results.combined_scores
+
+    # TODO: Check and see if miners are getting dropped scores
+    #       because the is-alive filter is too strict or broken
+    # rewards_tensor_adjusted = filter_rewards(
+    #     validator.isalive_dict,
+    #     validator.isalive_threshold,
+    #     # No need for scattering, directly use the rewards
+    #     scoring_results.combined_scores,
+    # )
 
     # Update moving averages
     validator.moving_average_scores = await update_moving_averages(

--- a/neurons/validator/rewards/models/__init__.py
+++ b/neurons/validator/rewards/models/__init__.py
@@ -13,27 +13,12 @@ from neurons.validator.rewards.models.human import HumanValidationRewardModel
 from neurons.validator.rewards.models.image_reward import ImageRewardModel
 from neurons.validator.rewards.models.nsfw import NSFWRewardModel
 
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
+from neurons.validator.rewards.models.types import (
+    ModelStorage,
+    PackedRewardModel,
+)
 
-
-class PackedRewardModel(BaseModel):
-    weight: float
-    model: BaseRewardModel
-
-    class Config:
-        arbitrary_types_allowed = True
-
-    @property
-    def name(self) -> RewardModelType:
-        return self.model.name
-
-    def apply(
-        self, *args, **kwargs
-    ) -> Tuple[torch.FloatTensor, torch.FloatTensor,]:
-        return self.model.apply(*args, **kwargs)
-
-
-ModelStorage = Dict[RewardModelType, PackedRewardModel]
 
 # Init Reward Models
 REWARD_MODELS: ModelStorage = None

--- a/neurons/validator/rewards/models/base.py
+++ b/neurons/validator/rewards/models/base.py
@@ -1,18 +1,22 @@
 from abc import abstractmethod
-from typing import Callable, List, Tuple, Dict
+from typing import Callable, List, TYPE_CHECKING
 
-import bittensor as bt
 import torch
+import bittensor as bt
 from loguru import logger
 
+
 from neurons.validator.config import get_device, get_metagraph
-from neurons.validator.rewards.types import RewardModelType, ScoringResult
+
+if TYPE_CHECKING:
+    from neurons.validator.rewards.types import ScoringResult
+    from neurons.validator.rewards.models.types import RewardModelType
 
 
 class BaseRewardModel:
     @property
     @abstractmethod
-    def name(self) -> RewardModelType:
+    def name(self) -> "RewardModelType":
         ...
 
     def is_strict_uid_scoring(self) -> float:
@@ -83,12 +87,14 @@ class BaseRewardModel:
         self,
         synapse: bt.Synapse,
         responses: List[bt.Synapse],
-    ) -> ScoringResult:
+    ) -> "ScoringResult":
         # Get rewards for the responses
         rewards = await self.get_rewards(synapse, responses)
 
         # Normalize rewards
         normalized_rewards = self.normalize_rewards(rewards)
+
+        from neurons.validator.rewards.types import ScoringResult
 
         return ScoringResult(
             scores=rewards,

--- a/neurons/validator/rewards/models/blacklist.py
+++ b/neurons/validator/rewards/models/blacklist.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from neurons.validator.config import get_device
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class BlacklistFilter(BaseRewardModel):

--- a/neurons/validator/rewards/models/empty.py
+++ b/neurons/validator/rewards/models/empty.py
@@ -1,6 +1,6 @@
 import bittensor as bt
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class EmptyScoreRewardModel(BaseRewardModel):

--- a/neurons/validator/rewards/models/human.py
+++ b/neurons/validator/rewards/models/human.py
@@ -6,7 +6,7 @@ import bittensor as bt
 import torch
 
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 from neurons.validator.config import get_backend_client, get_device, get_metagraph
 
 

--- a/neurons/validator/rewards/models/image_reward.py
+++ b/neurons/validator/rewards/models/image_reward.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 from neurons.validator.config import get_device
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class ImageRewardModel(BaseRewardModel):

--- a/neurons/validator/rewards/models/nsfw.py
+++ b/neurons/validator/rewards/models/nsfw.py
@@ -4,7 +4,7 @@ from transformers import CLIPImageProcessor
 from neurons.safety import StableDiffusionSafetyChecker
 from neurons.validator.config import get_device
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class NSFWRewardModel(BaseRewardModel):

--- a/neurons/validator/rewards/models/similarity.py
+++ b/neurons/validator/rewards/models/similarity.py
@@ -34,7 +34,7 @@ from neurons.miners.StableMiner.utils import warm_up
 from neurons.protocol import ImageGeneration
 from neurons.safety import StableDiffusionSafetyChecker
 from neurons.validator.rewards.models.base import BaseRewardModel
-from neurons.validator.rewards.types import RewardModelType
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class SimilarityRewardModel(BaseRewardModel):

--- a/neurons/validator/rewards/models/types.py
+++ b/neurons/validator/rewards/models/types.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel
+from enum import Enum
+from typing import Dict, Tuple
+
+import torch
+
+from neurons.validator.rewards.models.base import BaseRewardModel
+
+
+class RewardModelType(str, Enum):
+    # Masking models
+    # TODO: Maybe move these out
+    NSFW = "NSFW"
+    BLACKLIST = "BLACKLIST"
+
+    # Reward models
+    EMPTY = "EMPTY"
+    HUMAN = "HUMAN"
+    IMAGE = "IMAGE"
+    SIMILARITY = "SIMILARITY"
+
+
+class PackedRewardModel(BaseModel):
+    weight: float
+
+    model: BaseRewardModel
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @property
+    def name(self) -> RewardModelType:
+        return self.model.name
+
+    def apply(
+        self,
+        *args,
+        **kwargs,
+    ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:
+        return self.model.apply(*args, **kwargs)
+
+
+ModelStorage = Dict[RewardModelType, PackedRewardModel]

--- a/neurons/validator/rewards/pipeline.py
+++ b/neurons/validator/rewards/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List
 
 import torch
 import bittensor as bt
@@ -8,8 +8,8 @@ from neurons.protocol import ModelType
 from neurons.utils.log import summarize_rewards
 from neurons.validator.config import get_device, get_metagraph
 
+from neurons.validator.rewards.models.types import PackedRewardModel
 from neurons.validator.rewards.models import (
-    PackedRewardModel,
     get_reward_functions,
     get_masking_functions,
 )

--- a/neurons/validator/rewards/types.py
+++ b/neurons/validator/rewards/types.py
@@ -1,21 +1,9 @@
-from enum import Enum
 from typing import List, Optional
 
 import torch
 from pydantic import BaseModel, Field
 
-
-class RewardModelType(str, Enum):
-    # Masking models
-    # TODO: Maybe move these out
-    NSFW = "NSFW"
-    BLACKLIST = "BLACKLIST"
-
-    # Reward models
-    EMPTY = "EMPTY"
-    HUMAN = "HUMAN"
-    IMAGE = "IMAGE"
-    SIMILARITY = "SIMILARITY"
+from neurons.validator.rewards.models.types import RewardModelType
 
 
 class ScoringResult(BaseModel):

--- a/neurons/validator/utils/wandb.py
+++ b/neurons/validator/utils/wandb.py
@@ -10,7 +10,6 @@ from loguru import logger
 from neurons.constants import (
     WANDB_VALIDATOR_PATH,
 )
-from neurons.validator.rewards.models import get_reward_models
 from neurons.validator.utils.version import get_validator_version
 
 

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,408 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+import torch
+import bittensor as bt
+from loguru import logger
+
+from neurons.protocol import ImageGeneration, ModelType
+from neurons.validator.rewards.types import ScoringResults
+from neurons.validator.rewards.models import RewardModelType
+from neurons.validator.rewards.pipeline import (
+    get_scoring_results,
+    filter_rewards,
+)
+from neurons.validator.forward import update_moving_averages
+from neurons.constants import MOVING_AVERAGE_ALPHA
+from neurons.validator.backend.exceptions import PostMovingAveragesError
+
+
+# Mock functions
+def mock_metagraph():
+    test_uids = torch.tensor([0, 1, 2, 3, 4])
+    test_hotkeys = [f"hotkey_{uid.item()}" for uid in test_uids]
+    to_return = MagicMock()
+    to_return.n = len(test_hotkeys)
+    to_return.hotkeys = test_hotkeys
+    return to_return
+
+
+def mock_backend_client():
+    mock_client = AsyncMock()
+    mock_votes = {
+        "round_1": {
+            "hotkey_0": 1,
+            "hotkey_1": 2,
+        },
+        "round_2": {
+            "hotkey_2": 3,
+            "hotkey_3": 4,
+        },
+    }
+    mock_client.get_votes.return_value = mock_votes
+    return mock_client
+
+
+mock_meta = mock_metagraph()
+mock_client = mock_backend_client()
+
+
+def generate_synapse(hotkey: str, image_content: torch.Tensor) -> bt.Synapse:
+    synapse = ImageGeneration(
+        generation_type="TEXT_TO_IMAGE",
+        seed=-1,
+        model_type=ModelType.ALCHEMY.value,
+        images=[bt.Tensor.serialize(image_content)],
+    )
+    synapse.axon = bt.TerminalInfo(hotkey=hotkey)
+    return synapse
+
+
+# Updated MockImageRewardModel
+class MockImageRewardModel:
+    def __init__(self):
+        self.reward_values = {
+            "hotkey_0": 0.9,
+            "hotkey_1": 0.1,  # This will be the "black" image
+            "hotkey_2": 0.7,
+            "hotkey_3": 0.5,
+            "hotkey_4": 0.8,
+        }
+
+    @property
+    def name(self):
+        return RewardModelType.IMAGE
+
+    def get_reward(self, response: bt.Synapse) -> float:
+        # Return reward based on the hotkey
+        return self.reward_values.get(response.axon.hotkey, 0.5)
+
+
+async def run_pipeline_test():
+    # Generate test responses
+    responses = []
+    for i, hotkey in enumerate(mock_meta.hotkeys):
+        if i == 0:
+            image_content = torch.full(
+                [3, 1024, 1024],
+                200,
+                dtype=torch.float,
+            )
+        elif i == 1:
+            image_content = torch.zeros(
+                [3, 1024, 1024],
+                dtype=torch.float,
+            )
+        elif i == 2:
+            image_content = torch.full(
+                [3, 1024, 1024],
+                200,
+                dtype=torch.float,
+            )
+        else:
+            image_content = torch.full(
+                [3, 1024, 1024],
+                150 + i * 20,
+                dtype=torch.float,
+            )
+        responses.append(generate_synapse(hotkey, image_content))
+
+    # Patch the ImageRewardModel with our mock
+    with patch(
+        "neurons.validator.rewards.models.image_reward.ImageRewardModel",
+        MockImageRewardModel,
+    ):
+        # Run the full pipeline
+        results: ScoringResults = await get_scoring_results(
+            ModelType.CUSTOM, responses[0], responses
+        )
+
+    logger.info("Detailed scores for each reward type:")
+    for score in results.scores:
+        logger.info("{}: {}".format(score.type, score.scores))
+
+    logger.info("Combined scores before filtering: {}".format(results.combined_scores))
+
+    # Check if we have all expected score types
+    expected_score_types = {
+        RewardModelType.HUMAN,
+        RewardModelType.IMAGE,
+        RewardModelType.NSFW,
+        RewardModelType.BLACKLIST,
+    }
+    actual_score_types = {score.type for score in results.scores}
+    for expected_score_type in expected_score_types:
+        assert (
+            expected_score_type in actual_score_types
+        ), "Missing score type. Expected to contain: {}, Got: {}".format(
+            expected_score_type, actual_score_types
+        )
+
+    # Check human voting rewards
+    human_scores = results.get_score(RewardModelType.HUMAN).scores
+    assert (
+        human_scores[0] > 1 and human_scores[1] > human_scores[0]
+    ), "Human voting rewards not applied correctly"
+
+    # Check masking
+    assert results.combined_scores[1] == 0, "Black image not masked"
+
+    # Check if other scores are non-zero for valid images
+    for i in [0, 2, 3, 4]:
+        assert (
+            results.combined_scores[i] != 0
+        ), "Valid image {} incorrectly masked. Score: {}".format(
+            i, results.combined_scores[i]
+        )
+
+    # Test reward filtering
+    isalive_dict = {0: 10, 2: 5}  # Miner 0 exceeds threshold, 2 doesn't
+    isalive_threshold = 8
+    filtered_rewards = filter_rewards(
+        isalive_dict, isalive_threshold, results.combined_scores
+    )
+
+    logger.info("isalive_dict: {}".format(isalive_dict))
+    logger.info("isalive_threshold: {}".format(isalive_threshold))
+    logger.info("Final filtered rewards: {}".format(filtered_rewards))
+
+    assert (
+        filtered_rewards[0] == 0
+    ), "Rewards not zeroed for miner exceeding isalive threshold. Value: {}".format(
+        filtered_rewards[0]
+    )
+    assert (
+        filtered_rewards[2] != 0
+    ), "Rewards incorrectly zeroed for miner below isalive threshold. Value: {}".format(
+        filtered_rewards[2]
+    )
+
+    # Check if miners not in isalive_dict retain their original scores
+    for i in range(1, 5):  # Checking miners 1, 3, and 4
+        if i != 2:  # Skip 2 as it's in isalive_dict
+            assert (
+                filtered_rewards[i] == results.combined_scores[i]
+            ), "Reward for miner {} changed unexpectedly. Before: {}, After: {}".format(
+                i, results.combined_scores[i], filtered_rewards[i]
+            )
+
+    # Check if final scores are within the correct range (0 to 1)
+    assert torch.all(
+        (filtered_rewards >= 0) & (filtered_rewards <= 1)
+    ), "Final rewards not in range [0, 1]: {}".format(filtered_rewards)
+
+    # Analyze the order of rewards
+    non_zero_rewards = filtered_rewards[filtered_rewards != 0]
+    sorted_rewards, indices = torch.sort(non_zero_rewards, descending=True)
+    logger.info("Non-zero rewards: {}".format(non_zero_rewards))
+    logger.info("Sorted non-zero rewards: {}".format(sorted_rewards))
+    logger.info("Indices of sorted rewards: {}".format(indices))
+
+    # Instead of asserting the exact order, we can check if the highest reward is significantly higher than the lowest
+    assert (
+        sorted_rewards[0] > sorted_rewards[-1] * 1.5
+    ), "Highest reward ({}) is not significantly higher than lowest reward ({})".format(
+        sorted_rewards[0], sorted_rewards[-1]
+    )
+
+    return results, filtered_rewards
+
+
+class MockBackendClient:
+    def __init__(self, should_fail=False):
+        self.should_fail = should_fail
+        self.post_moving_averages_called = 0
+
+    async def post_moving_averages(self, hotkeys, moving_average_scores):
+        self.post_moving_averages_called += 1
+        if self.should_fail:
+            raise PostMovingAveragesError("Mocked error")
+
+
+@pytest.mark.asyncio
+@patch(
+    "neurons.validator.config.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.config.get_backend_client",
+    return_value=mock_client,
+)
+@patch(
+    "neurons.validator.rewards.models.base.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.pipeline.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.models.human.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.models.human.get_backend_client",
+    return_value=mock_client,
+)
+@patch(
+    "neurons.validator.rewards.models.image_reward.ImageRewardModel",
+    MockImageRewardModel,
+)
+async def test_full_pipeline_integration_multiple_runs(*mocks):
+    num_runs = 5
+    all_results = []
+    all_filtered_rewards = []
+
+    for run in range(num_runs):
+        logger.info("Starting run {} of {}".format(run + 1, num_runs))
+        results, filtered_rewards = await run_pipeline_test()
+        all_results.append(results)
+        all_filtered_rewards.append(filtered_rewards)
+
+    # Check consistency across runs
+    for i in range(1, num_runs):
+        assert torch.allclose(
+            all_filtered_rewards[0], all_filtered_rewards[i], atol=1e-6
+        ), "Inconsistent results between run 1 and run {}".format(i + 1)
+
+    # Additional consistency checks
+    for run in range(num_runs):
+        assert len(all_results[run].scores) == len(
+            all_results[0].scores
+        ), "Inconsistent number of score types in run {}".format(run + 1)
+        for idx, score_0 in enumerate(all_results[0].scores):
+            score_type_0 = score_0.type
+            score_run = all_results[run].scores[idx]
+            score_type_run = score_run.type
+
+            assert score_type_0 == score_type_run, (
+                f"Mismatched score types at index {idx} in run {run + 1}."
+                + f" Expected {score_type_0}, got {score_type_run}"
+            )
+
+            assert torch.allclose(score_0.scores, score_run.scores, atol=1e-6), (
+                f"Inconsistent scores for {score_type_0} in run {run + 1}. "
+                f"Run 0 scores: {score_0.scores}, Run {run + 1} scores: {score_run.scores}"
+            )
+
+    logger.info("All runs completed successfully with consistent results!")
+
+
+@pytest.mark.asyncio
+@patch(
+    "neurons.validator.config.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.config.get_backend_client",
+    return_value=mock_client,
+)
+@patch(
+    "neurons.validator.rewards.models.base.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.pipeline.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.models.human.get_metagraph",
+    return_value=mock_meta,
+)
+@patch(
+    "neurons.validator.rewards.models.human.get_backend_client",
+    return_value=mock_client,
+)
+@patch(
+    "neurons.validator.rewards.models.image_reward.ImageRewardModel",
+    MockImageRewardModel,
+)
+async def test_full_pipeline_integration_with_moving_averages(*mocks):
+    num_runs = 3
+    all_results = []
+    all_filtered_rewards = []
+    moving_average_scores = torch.zeros(5)  # Assuming 5 miners
+    ma_history = [moving_average_scores.clone()]
+
+    mock_backend_client = MockBackendClient()
+    with patch(
+        "neurons.validator.forward.get_backend_client", return_value=mock_backend_client
+    ):
+        for run in range(num_runs):
+            logger.info("Starting run {} of {}".format(run + 1, num_runs))
+            results, filtered_rewards = await run_pipeline_test()
+            all_results.append(results)
+            all_filtered_rewards.append(filtered_rewards)
+
+            # Update moving averages
+            moving_average_scores = await update_moving_averages(
+                moving_average_scores, filtered_rewards
+            )
+            ma_history.append(moving_average_scores.clone())
+
+            logger.info(
+                f"Run {run + 1} - Updated moving average scores: {moving_average_scores}"
+            )
+
+    assert (
+        mock_backend_client.post_moving_averages_called == num_runs
+    ), "Backend client should be called once per run"
+
+    # Check consistency across runs
+    for i in range(1, num_runs):
+        assert torch.allclose(
+            all_filtered_rewards[0], all_filtered_rewards[i], atol=1e-6
+        ), "Inconsistent filtered rewards between run 1 and run {}".format(i + 1)
+
+    # Additional consistency checks
+    for run in range(num_runs):
+        assert len(all_results[run].scores) == len(
+            all_results[0].scores
+        ), "Inconsistent number of score types in run {}".format(run + 1)
+
+        for idx, score_0 in enumerate(all_results[0].scores):
+            score_type_0 = score_0.type
+            score_run = all_results[run].scores[idx]
+            score_type_run = score_run.type
+
+            assert (
+                score_type_0 == score_type_run
+            ), f"Mismatched score types at index {idx} in run {run + 1}. Expected {score_type_0}, got {score_type_run}"
+
+            assert (
+                score_0.scores is not None
+            ), f"Score type {score_type_0} returned None scores in run 0"
+            assert (
+                score_run.scores is not None
+            ), f"Score type {score_type_0} returned None scores in run {run + 1}"
+
+            try:
+                assert torch.allclose(score_0.scores, score_run.scores, atol=1e-6), (
+                    f"Inconsistent scores for {score_type_0} in run {run + 1}. "
+                    f"Run 0 scores: {score_0.scores}, Run {run + 1} scores: {score_run.scores}"
+                )
+            except AssertionError as e:
+                logger.error(f"Assertion failed: {str(e)}")
+                logger.info(f"Score type: {score_type_0}")
+                logger.info(f"Run 0 scores: {score_0.scores}")
+                logger.info(f"Run {run + 1} scores: {score_run.scores}")
+                raise
+
+    # Check if final moving average scores are within expected range
+    assert torch.all(
+        (moving_average_scores >= 0) & (moving_average_scores <= 1)
+    ), "Final moving average scores not in range [0, 1]: {}".format(
+        moving_average_scores
+    )
+
+    # Verify that moving averages have changed over time
+    assert not torch.allclose(
+        ma_history[0], ma_history[-1], atol=1e-6
+    ), "Moving averages should change over multiple runs"
+
+    logger.info("All runs completed successfully with consistent results!")
+    logger.info(f"Initial moving average scores: {ma_history[0]}")
+    logger.info(f"Final moving average scores: {ma_history[-1]}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_unit_human_reward_socres.py
+++ b/tests/test_unit_human_reward_socres.py
@@ -84,9 +84,9 @@ async def test_apply_human_voting_weight():
         apply_function,
         apply_reward_functions,
     )
+    from neurons.validator.rewards.models.types import PackedRewardModel
     from neurons.validator.rewards.models import (
         RewardModelType,
-        PackedRewardModel,
         EmptyScoreRewardModel,
         HumanValidationRewardModel,
     )


### PR DESCRIPTION
- Add multiple moving average integration test
- Disable the isalive filter for now (test fix for miners with false low scores)
- Ignore stake below threshold error on validator
- Fix recursive import issue